### PR TITLE
Introduce MockAutoloader

### DIFF
--- a/src/Magento/Framework/App/RequestInterface.php
+++ b/src/Magento/Framework/App/RequestInterface.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Magento\Framework\App;
+
+use Magento\Framework\HTTP\PhpEnvironment\Request;
+
+/**
+ * @api
+ * @since 100.0.2
+ */
+interface RequestInterface
+{
+    /**
+     * Retrieve module name
+     *
+     * @return string
+     */
+    public function getModuleName();
+
+    /**
+     * Set Module name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setModuleName($name);
+
+    /**
+     * Retrieve action name
+     *
+     * @return string
+     */
+    public function getActionName();
+
+    /**
+     * Set action name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setActionName($name);
+
+    /**
+     * Retrieve param by key
+     *
+     * @param string $key
+     * @param mixed $defaultValue
+     * @return mixed
+     */
+    public function getParam($key, $defaultValue = null);
+
+    /**
+     * Set params from key value array
+     *
+     * @param array $params
+     * @return $this
+     */
+    public function setParams(array $params);
+
+    /**
+     * Retrieve all params as array
+     *
+     * @return array
+     */
+    public function getParams();
+
+    /**
+     * Retrieve cookie value
+     *
+     * @param string|null $name
+     * @param string|null $default
+     * @return string|null
+     */
+    public function getCookie($name, $default);
+
+    /**
+     * Returns whether request was delivered over HTTPS
+     *
+     * @return bool
+     */
+    public function isSecure();
+
+    //
+    // additional interface methods below...
+    //
+
+    /**
+     * Set flag indicating whether or not request has been dispatched
+     *
+     * @param boolean $flag
+     * @return $this
+     */
+    public function setDispatched($flag = true);
+}

--- a/src/Magento/Store/Api/Data/StoreInterface.php
+++ b/src/Magento/Store/Api/Data/StoreInterface.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Magento\Store\Api\Data;
+
+use Magento\Framework\UrlInterface;
+
+/**
+ * Store interface
+ *
+ * @api
+ * @since 100.0.2
+ */
+interface StoreInterface extends \Magento\Framework\Api\ExtensibleDataInterface
+{
+    /**
+     * @return int
+     */
+    public function getId();
+
+    /**
+     * @param int $id
+     * @return $this
+     */
+    public function setId($id);
+
+    /**
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * @param string $code
+     * @return $this
+     */
+    public function setCode($code);
+
+    /**
+     * Retrieve store name
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Set store name
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function setName($name);
+
+    /**
+     * @return int
+     */
+    public function getWebsiteId();
+
+    /**
+     * @param int $websiteId
+     * @return $this
+     */
+    public function setWebsiteId($websiteId);
+
+    /**
+     * @return int
+     */
+    public function getStoreGroupId();
+
+    /**
+     * @param int $isActive
+     * @return $this
+     */
+    public function setIsActive($isActive);
+
+    /**
+     * @return int
+     */
+    public function getIsActive();
+
+    /**
+     * @param int $storeGroupId
+     * @return $this
+     */
+    public function setStoreGroupId($storeGroupId);
+
+    /**
+     * Retrieve existing extension attributes object or create a new one.
+     *
+     * @return \Magento\Store\Api\Data\StoreExtensionInterface|null
+     */
+    public function getExtensionAttributes();
+
+    /**
+     * Set an extension attributes object.
+     *
+     * @param \Magento\Store\Api\Data\StoreExtensionInterface $extensionAttributes
+     * @return $this
+     */
+    public function setExtensionAttributes(
+        \Magento\Store\Api\Data\StoreExtensionInterface $extensionAttributes
+    );
+
+    //
+    // additional interface methods below...
+    //
+
+    /**
+     * Retrieve base URL
+     *
+     * @param string $type
+     * @param boolean|null $secure
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    public function getBaseUrl($type = \Magento\Framework\UrlInterface::URL_TYPE_LINK, $secure = null);
+}

--- a/src/bitExpert/PHPStan/Magento/Autoload/MockAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/MockAutoloader.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload;
+
+/**
+ * The MockAutoloader is responsible to load custom mocked classes or interfaces instead of the original Magento classes
+ * or interfaces. This is needed as not all interfaces expose all public methods that can be called on those objects.
+ */
+class MockAutoloader
+{
+    public function autoload(string $class): void
+    {
+        $filename = realpath(__DIR__ . '/../../../../' . str_replace('\\', '/', $class) . '.php');
+        if (file_exists($filename) && is_readable($filename)) {
+            include($filename);
+        }
+    }
+}


### PR DESCRIPTION
The MockAutoloader can be used to "overwrite" existing Magento classes and replace them with local copies. This is needed as not all interfaces expose all methods that can be called. Until this is fixed in Magento the mechanism can make sure that PHPStan knows about those methods and does not complain.