### PR TITLE
Add features section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ includes:
 	- vendor/bitexpert/phpstan-magento/extension.neon
 ```
 
+## Features
+1. The extension adds an class generator for factory & proxy classes similar as Magento does it. When running PHPStan in context of a Magento application this is not needed if you point PHPStan also the the generated files folder. When running Magento in a context of a module, this is required so that PHPStan get's the full picture of all classes needed.
+2. The extension adds an autoloader for "mocked" classes. These are classes that replace the Magento specific implementations to fix problems with type hints or missing methods in interfaces and such. The autoloader will check if a class, interface or trait exists locally in the extension. If so, it will load the local version instead of the one being shipped by Magento. Once those problems are fixed in Magento, those mocks can be removed again.
+3. A type extension was added so that `ObjectManager` calls return the correct return type.
+4. For some classes like the `DataObject` or the `SessionManager` logic was added to be able to support magic method calls.
+
 ## Known Issues
 
 Below is a list of known issues when using this extension:


### PR DESCRIPTION
I was wondering what the extension actually does and found https://blog.bitexpert.de/blog/using-phpstan-to-detect-errors-in-your-magento-project/. I blindly copy-pasted the text from there. It just makes it easier to understand what this extension does :-)