### PR TITLE
Optimize detection of DataObject parent class

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
+++ b/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
@@ -25,10 +25,8 @@ class DataObjectMagicMethodReflectionExtension extends AbstractMagicMethodReflec
      */
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        $isDataObject = $classReflection->getName() === DataObject::class ||
-                        $classReflection->isSubclassOf(DataObject::class);
-
-        return $isDataObject &&
+        $parentClasses = $classReflection->getParentClassesNames();
+        return in_array(DataObject::class, $parentClasses, true) &&
             in_array(substr($methodName, 0, 3), ['get', 'set', 'uns', 'has']);
     }
 }


### PR DESCRIPTION
Apparently $classReflection->isSubclassOf() does not take the whole inheritance chain into account, it will just check if the direct parent class is DataObject.