### PR TITLE
Provide default autoload.php for PHPStan phar

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,12 @@ Below is a list of known issues when using this extension:
 
 This is because the PHPStan shim is included as a phar archive and does therefore not support overriding certain methods in it's namespace. The current known fix for this is to manually load the autoloader that comes with this extension.
 
-Create a file in your project (for example `phpstan.php`) with the following content:
-
-```php
-<?php
-\bitExpert\PHPStan\Magento\Autoload\Autoloader::register();
-```
-
-Include this to the `autoload_files`-section of your `phpstan.neon`:
+Include the autoload.php file in the `autoload_files`-section of your `phpstan.neon`:
 
 ```neon
 parameters:
     autoload_files:
-        - phpstan.php
+        - vendor/bitexpert/phpstan-magento/autoload.php
 ```
 
 ## Contribute

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Include this file if you are using the phar version of PHPStan. Since the phar version make use of dynamic namespaces
+// the hack in registration.php to overload spl_autoload_register() and spl_autoload_unregister() does not work any more.
+\bitExpert\PHPStan\Magento\Autoload\Autoloader::register();


### PR DESCRIPTION
Since the phar version makes use of dynamic namespaces the hack in registration.php to overload spl_autoload_register() and spl_autoload_unregister() does not work anymore. This PR adds a default autoload.php file which can be included via PHPStan's config file.