### PR TITLE
Fix Magic Method call on a DataObject instance

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
+++ b/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
@@ -26,7 +26,11 @@ class DataObjectMagicMethodReflectionExtension extends AbstractMagicMethodReflec
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
         $parentClasses = $classReflection->getParentClassesNames();
-        return in_array(DataObject::class, $parentClasses, true) &&
+
+        $isDataObject = $classReflection->getName() === DataObject::class ||
+                        in_array(DataObject::class, $parentClasses, true);
+
+        return $isDataObject &&
             in_array(substr($methodName, 0, 3), ['get', 'set', 'uns', 'has']);
     }
 }


### PR DESCRIPTION
Commit https://github.com/bitExpert/phpstan-magento/commit/a72458ce869ee00ae011e30fb4c5a215cd9ee1c1 broke the fix added in https://github.com/bitExpert/phpstan-magento/pull/12

Without this fix, I'm getting the following error when executing phpstan:
```
Call to an undefined method Magento\Framework\DataObject::setSomeProperty()

```