### PR TITLE
Make DataObject extension stricter

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
+++ b/src/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtension.php
@@ -26,11 +26,9 @@ class DataObjectMagicMethodReflectionExtension extends AbstractMagicMethodReflec
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
         $parentClasses = $classReflection->getParentClassesNames();
+        $parentClasses[] = $classReflection->getName();
 
-        $isDataObject = $classReflection->getName() === DataObject::class ||
-                        in_array(DataObject::class, $parentClasses, true);
-
-        return $isDataObject &&
+        return in_array(DataObject::class, $parentClasses, true) &&
             in_array(substr($methodName, 0, 3), ['get', 'set', 'uns', 'has']);
     }
 }

--- a/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Reflection\Framework;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use PHPUnit\Framework\TestCase;
+
+class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
+{
+    /**
+     * @var DataObjectMagicMethodReflectionExtension
+     */
+    private $extension;
+    /**
+     * @var ClassReflection|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $classReflection;
+
+    protected function setUp(): void
+    {
+        $this->extension = new DataObjectMagicMethodReflectionExtension();
+        $this->classReflection = $this->createMock(ClassReflection::class);
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForGetMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'getTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(MixedType::class, $variants[0]->getReturnType());
+        $this->assertCount(2, $params);
+        $this->assertInstanceOf(StringType::class, $params[0]->getType());
+        $this->assertInstanceOf(UnionType::class, $params[1]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForSetMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'setTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(ObjectType::class, $variants[0]->getReturnType());
+        $this->assertCount(2, $params);
+        $this->assertInstanceOf(UnionType::class, $params[0]->getType());
+        $this->assertInstanceOf(MixedType::class, $params[1]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForUnsetMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'unsetTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(ObjectType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(UnionType::class, $params[0]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForHasMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'hasTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(BooleanType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(StringType::class, $params[0]->getType());
+    }
+}


### PR DESCRIPTION
Instead of accepting and returning mixed types, the extension now accepts and returns types based on the magic method documentation in the DataObject class.