### PR TITLE
Removes upper version constraint of phpstan

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ includes:
 	- vendor/bitexpert/phpstan-magento/extension.neon
 ```
 
+⚠️ When you use a version of `phpstan/phpstan` lower than 0.12.26 you should replace `bootstrapFiles` with `autoload_files` in the configuration mentioned above.
+
 ## Features
 
 ### Class generator for factory & proxy classes

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": "^7.2.0",
     "magento/framework": ">=101.0.0",
     "nette/neon": "^3.1",
-    "phpstan/phpstan": ">=0.12.3 <=0.12.23"
+    "phpstan/phpstan": "^0.12.23"
   },
   "require-dev": {
     "bitexpert/phing-securitychecker": "^0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87ea59cb8e91d496d22a798aac7198bf",
+    "content-hash": "275574037484e89b8a8a36aa366c7422",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -2419,20 +2419,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.23",
+            "version": "0.12.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75"
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/71e529efced79e055fa8318b692e7f7d03ea4e75",
-                "reference": "71e529efced79e055fa8318b692e7f7d03ea4e75",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
+                "reference": "e96dd5e7ae9aefed663bc7e285ad96792b67eadc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -2471,7 +2471,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-05T12:55:44+00:00"
+            "time": "2020-10-25T07:23:44+00:00"
         },
         {
             "name": "psr/container",
@@ -5054,6 +5054,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {


### PR DESCRIPTION
Fixes #42, replaces #43

My Engrish might not be super good, so if the warning should be phrased differently, let me know! 🙂 

Only took me 5 attempts with the captain hooks configuration for writing a valid commit message 😆 