### PR TITLE
Fix params for DataObject get & set

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Reflection/AbstractMagicMethodReflectionExtension.php
+++ b/src/bitExpert/PHPStan/Magento/Reflection/AbstractMagicMethodReflectionExtension.php
@@ -34,6 +34,7 @@ abstract class AbstractMagicMethodReflectionExtension implements MethodsClassRef
      * @param ClassReflection $classReflection
      * @param string $methodName
      * @return MethodReflection
+     * @throws ShouldNotHappenException
      */
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
@@ -58,27 +59,42 @@ abstract class AbstractMagicMethodReflectionExtension implements MethodsClassRef
      * @param ClassReflection $classReflection
      * @param string $methodName
      * @return MethodReflection
+     * @throws ShouldNotHappenException
      */
-    private function returnGetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    protected function returnGetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        $params = [
-            new DummyParameter(
-                'key',
-                new StringType(),
-                true,
-                null,
-                false,
-                null
-            ),
-            new DummyParameter(
-                'index',
-                new UnionType([new StringType(), new IntegerType(), new NullType()]),
-                true,
-                null,
-                false,
-                null
-            )
-        ];
+        $params = [];
+        if ($methodName === 'getData') {
+            $params = [
+                new DummyParameter(
+                    'key',
+                    new StringType(),
+                    true,
+                    null,
+                    false,
+                    null
+                ),
+                new DummyParameter(
+                    'index',
+                    new UnionType([new StringType(), new IntegerType(), new NullType()]),
+                    true,
+                    null,
+                    false,
+                    null
+                )
+            ];
+        } else {
+            $params = [
+                new DummyParameter(
+                    'value',
+                    new MixedType(),
+                    true,
+                    null,
+                    false,
+                    null
+                )
+            ];
+        }
 
         $returnType = new MixedType();
 
@@ -93,26 +109,48 @@ abstract class AbstractMagicMethodReflectionExtension implements MethodsClassRef
         return new MagicMethodReflection($methodName, $classReflection, [$variants]);
     }
 
-    private function returnSetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    /**
+     * Helper method to create magic method reflection for set() calls.
+     *
+     * @param ClassReflection $classReflection
+     * @param string $methodName
+     * @return MethodReflection
+     * @throws ShouldNotHappenException
+     */
+    protected function returnSetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        $params = [
-            new DummyParameter(
-                'key',
-                new UnionType([new StringType(), new ArrayType(new MixedType(), new MixedType())]),
-                true,
-                null,
-                false,
-                null
-            ),
-            new DummyParameter(
-                'value',
-                new MixedType(),
-                true,
-                null,
-                false,
-                null
-            )
-        ];
+        $params = [];
+        if ($methodName === 'setData') {
+            $params = [
+                new DummyParameter(
+                    'key',
+                    new UnionType([new StringType(), new ArrayType(new MixedType(), new MixedType())]),
+                    true,
+                    null,
+                    false,
+                    null
+                ),
+                new DummyParameter(
+                    'value',
+                    new MixedType(),
+                    true,
+                    null,
+                    false,
+                    null
+                )
+            ];
+        } else {
+            $params = [
+                new DummyParameter(
+                    'value',
+                    new MixedType(),
+                    true,
+                    null,
+                    false,
+                    null
+                )
+            ];
+        }
 
         $returnType = new ObjectType($classReflection->getName());
 
@@ -127,7 +165,15 @@ abstract class AbstractMagicMethodReflectionExtension implements MethodsClassRef
         return new MagicMethodReflection($methodName, $classReflection, [$variants]);
     }
 
-    private function returnUnsetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    /**
+     * Helper method to create magic method reflection for unset() calls.
+     *
+     * @param ClassReflection $classReflection
+     * @param string $methodName
+     * @return MethodReflection
+     * @throws ShouldNotHappenException
+     */
+    protected function returnUnsetMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
         $params = [
             new DummyParameter(
@@ -153,18 +199,28 @@ abstract class AbstractMagicMethodReflectionExtension implements MethodsClassRef
         return new MagicMethodReflection($methodName, $classReflection, [$variants]);
     }
 
-    private function returnHasMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    /**
+     * Helper method to create magic method reflection for has() calls.
+     *
+     * @param ClassReflection $classReflection
+     * @param string $methodName
+     * @return MethodReflection
+     */
+    protected function returnHasMagicMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        $params = [
-            new DummyParameter(
-                'key',
-                new StringType(),
-                true,
-                null,
-                false,
-                null
-            )
-        ];
+        $params = [];
+        if ($methodName === 'hasData') {
+            $params = [
+                new DummyParameter(
+                    'key',
+                    new StringType(),
+                    true,
+                    null,
+                    false,
+                    null
+                )
+            ];
+        }
 
         $returnType = new BooleanType();
 

--- a/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
@@ -27,6 +27,7 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
      * @var DataObjectMagicMethodReflectionExtension
      */
     private $extension;
+
     /**
      * @var ClassReflection|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -41,9 +42,9 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
     /**
      * @test
      */
-    public function returnMagicMethodReflectionForGetMethod(): void
+    public function returnMagicMethodReflectionForGetDataMethod(): void
     {
-        $methodReflection = $this->extension->getMethod($this->classReflection, 'getTest');
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'getData');
 
         $variants = $methodReflection->getVariants();
         $params = $variants[0]->getParameters();
@@ -58,9 +59,25 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
     /**
      * @test
      */
-    public function returnMagicMethodReflectionForSetMethod(): void
+    public function returnMagicMethodReflectionForGetMethod(): void
     {
-        $methodReflection = $this->extension->getMethod($this->classReflection, 'setTest');
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'getTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(MixedType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(MixedType::class, $params[0]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForSetDataMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'setData');
 
         $variants = $methodReflection->getVariants();
         $params = $variants[0]->getParameters();
@@ -70,6 +87,22 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
         $this->assertCount(2, $params);
         $this->assertInstanceOf(UnionType::class, $params[0]->getType());
         $this->assertInstanceOf(MixedType::class, $params[1]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForSetMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'setTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(ObjectType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(MixedType::class, $params[0]->getType());
     }
 
     /**
@@ -91,6 +124,22 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
     /**
      * @test
      */
+    public function returnMagicMethodReflectionForHasDataMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'hasData');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(BooleanType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(StringType::class, $params[0]->getType());
+    }
+
+    /**
+     * @test
+     */
     public function returnMagicMethodReflectionForHasMethod(): void
     {
         $methodReflection = $this->extension->getMethod($this->classReflection, 'hasTest');
@@ -100,8 +149,7 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends TestCase
 
         $this->assertCount(1, $variants);
         $this->assertInstanceOf(BooleanType::class, $variants[0]->getReturnType());
-        $this->assertCount(1, $params);
-        $this->assertInstanceOf(StringType::class, $params[0]->getType());
+        $this->assertCount(0, $params);
     }
 
     /**

--- a/tests/bitExpert/PHPStan/Magento/Reflection/Framework/Session/SessionManagerMagicMethodReflectionExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Reflection/Framework/Session/SessionManagerMagicMethodReflectionExtensionUnitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Reflection\Framework\Session;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPUnit\Framework\TestCase;
+
+class SessionManagerMagicMethodReflectionExtensionUnitTest extends TestCase
+{
+
+    /**
+     * @var SessionManagerMagicMethodReflectionExtension
+     */
+    private $extension;
+
+    /**
+     * @var ClassReflection|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $classReflection;
+
+    protected function setUp(): void
+    {
+        $this->extension = new SessionManagerMagicMethodReflectionExtension();
+        $this->classReflection = $this->createMock(ClassReflection::class);
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForGetDataMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'getData');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(MixedType::class, $variants[0]->getReturnType());
+        $this->assertCount(2, $params);
+        $this->assertInstanceOf(StringType::class, $params[0]->getType());
+        $this->assertInstanceOf(BooleanType::class, $params[1]->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function returnMagicMethodReflectionForGetMethod(): void
+    {
+        $methodReflection = $this->extension->getMethod($this->classReflection, 'getTest');
+
+        $variants = $methodReflection->getVariants();
+        $params = $variants[0]->getParameters();
+
+        $this->assertCount(1, $variants);
+        $this->assertInstanceOf(MixedType::class, $variants[0]->getReturnType());
+        $this->assertCount(1, $params);
+        $this->assertInstanceOf(MixedType::class, $params[0]->getType());
+    }
+}


### PR DESCRIPTION
The logic in AbstractMagicMethodReflectionExtension needed to be extended to deal with both `getData("Var")` and `getVar()`  invocations. Fixes #51. 

Also added a distinction between `DataObject::getData()` and `Session\Storage::getData()`.
