### PR TITLE
Install matching lowest version of strict rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install lowest PHPStan version
         if: matrix.composer-prefer-lowest == true
         run: |
-          composer remove phpstan/phpstan phpstan/phpstan-phpunit
-          composer require --prefer-lowest phpstan/phpstan:0.12.23 phpstan/phpstan-phpunit:0.12.11
+          composer remove --no-update phpstan/phpstan phpstan/phpstan-phpunit phpstan/phpstan-strict-rules
+          composer require --prefer-lowest phpstan/phpstan:0.12.23 phpstan/phpstan-phpunit:0.12.11 phpstan/phpstan-strict-rules:0.12.3
 
       - name: Codesniffer
         run: composer cs-check


### PR DESCRIPTION
#67 broke CI, this PR fixes it: When downgrading phpstan to the version shipped with Magento 2.4.0, downgrade to the matching version of the strict rules package.