### PR TITLE
Omit namespace for non-namespace Factory

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Autoload/FactoryAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/FactoryAutoloader.php
@@ -61,7 +61,11 @@ class FactoryAutoloader
         $namespace = implode('\\', $namespace);
 
         $template = "<?php\n";
-        $template .= "namespace {NAMESPACE};\n\n";
+
+        if ($namespace !== '') {
+            $template .= "namespace {NAMESPACE};\n\n";
+        }
+
         $template .= "/**\n";
         $template .= " * Factory class for @see \{NAMESPACE}\{CLASSNAME}\n";
         $template .= " */\n";


### PR DESCRIPTION
If we use Factory in the code for a class that does not have a namespace, phpstan will return an error.

For example: `use Zend_Db_Adapter_SqlsrvFactory`

In this case, the generated file has an empty namespace.

This pull request adds a condition that makes this case remain without a namespace.

**Before:**
![image](https://user-images.githubusercontent.com/7402947/128191298-2e942d10-b2ba-4190-99f3-41188df3c75a.png)

**After:**
![image](https://user-images.githubusercontent.com/7402947/128191503-f4813b06-122a-43ab-95bd-4eb3fece13ac.png)
