### PR TITLE
Omit namespace for non-namespace Proxy

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Autoload/ProxyAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/ProxyAutoloader.php
@@ -113,7 +113,11 @@ class ProxyAutoloader
         }
 
         $template = "<?php\n";
-        $template .= "namespace {NAMESPACE};\n";
+
+        if ($namespace !== '') {
+            $template .= "namespace {NAMESPACE};\n\n";
+        }
+
         $template .= "/**\n";
         $template .= " * Proxy class for @see {CLASSNAME}\n";
         $template .= " */\n";


### PR DESCRIPTION
Apply the logic of #132 also for the proxy class autoloader: Omit the namespace in the generated file if the source class does not contain a namespace element.