### PR TITLE
Throw exception in autoloader

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -15,17 +15,19 @@ use bitExpert\PHPStan\Magento\Autoload\Autoloader;
 use PHPStan\DependencyInjection\Container;
 
 if (!isset($container) || !$container instanceof Container) {
-    echo 'No container found, or container not of expected type' . PHP_EOL;
-    die(-1);
+    throw new \RuntimeException('No container found, or container not of expected type');
 }
 
 foreach ($container->getServicesByTag('phpstan.magento.autoloader') as $autoloader) {
     /** @var Autoloader|object $autoloader */
     if (!$autoloader instanceof Autoloader) {
-        echo 'Services tagged with \'phpstan.magento.autoloader\' must extend ' .
-            'bitExpert\PHPStan\Magento\Autoload\Autoloader!' . PHP_EOL .
-            get_class($autoloader) . ' does not.' . PHP_EOL;
-        die(-1);
+        throw new \RuntimeException(
+            sprintf(
+                'Service "%s" tagged with "phpstan.magento.autoloader" must implement %s!',
+                get_class($autoloader),
+                'bitExpert\PHPStan\Magento\Autoload\Autoloader'
+            )
+        );
     }
 
     $autoloader->register();


### PR DESCRIPTION
Optimization for #163: Replaced the echo/die logic by throwing an exception to let PHPStan terminate cleanly.