### PR TITLE
Remove nette/neon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "php": "^7.2.0 | ^8.0.0",
     "ext-dom": "*",
     "laminas/laminas-code": "~3.3.0 | ~3.4.1 | ~3.5.1",
-    "nette/neon": "^3.3.1",
     "phpstan/phpstan": "^1.1.0"
   },
   "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e047e1752d9ac9def55f5f14cb09c9f2",
+    "content-hash": "ffbf61b99e74efa76c62cf5162f98e4b",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -201,74 +201,6 @@
                 }
             ],
             "time": "2021-12-21T14:34:37+00:00"
-        },
-        {
-            "name": "nette/neon",
-            "version": "v3.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/neon.git",
-                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/54b287d8c2cdbe577b02e28ca1713e275b05ece2",
-                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.7"
-            },
-            "bin": [
-                "bin/neon-lint"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
-            "homepage": "https://ne-on.org",
-            "keywords": [
-                "export",
-                "import",
-                "neon",
-                "nette",
-                "yaml"
-            ],
-            "support": {
-                "issues": "https://github.com/nette/neon/issues",
-                "source": "https://github.com/nette/neon/tree/v3.3.2"
-            },
-            "time": "2021-11-25T15:57:41+00:00"
         },
         {
             "name": "phpstan/phpstan",


### PR DESCRIPTION
Due to the changes in #163 we don't need the nette/neon dependency anymore, since we don't have to re-parse the PHPStan configuration file. The autoloader gets the DI container injected which we then can use to pull all dependencies we need from.
