### PR TITLE
Lint neon files in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Codesniffer
         run: composer cs-check
 
+      - name: Neon linting
+        run: |
+          ./bin/ci_neon_lint
+          ./bin/ci_markdown_neon_lint
+
       - name: Static code analysis
         run: composer analyze
 

--- a/bin/ci_markdown_neon_lint
+++ b/bin/ci_markdown_neon_lint
@@ -1,0 +1,57 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// inspired by https://github.com/mathiasverraes/uptodocs this CLI script will lint
+// the Neon snippets in the Markdown files like README.md
+
+$path = realpath(__DIR__ . '/../');
+$it = new RecursiveDirectoryIterator($path);
+$it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::LEAVES_ONLY);
+$it = new RegexIterator($it, '~\.md$~');
+
+$environment = new \League\CommonMark\Environment();
+$environment->addExtension(new \League\CommonMark\Extension\CommonMarkCoreExtension());
+$parser = new \League\CommonMark\DocParser($environment);
+
+$success = true;
+foreach ($it as $file) {
+    /** @var SplFileInfo $file */
+    if (strpos($file->getRealPath(), '/vendor/') !== false) {
+        continue;
+    }
+
+    $nodeCount = 0;
+    $content = file_get_contents($file->getRealPath());
+    $document = $parser->parse($content);
+    $walker = $document->walker();
+    while ($event = $walker->next()) {
+        if ($event->getNode() instanceof \League\CommonMark\Block\Element\FencedCode
+            && $event->isEntering()
+            && $event->getNode()->getInfo() === 'neon') {
+
+            try {
+                $nodeCount++;
+                $node = $event->getNode();
+                Nette\Neon\Neon::decode($codeBlock = $node->getStringContent());
+            } catch (Nette\Neon\Exception $e) {
+                $success = false;
+                $relPath = str_replace($path . DIRECTORY_SEPARATOR, '', $file->getRealPath());
+                echo "Failed parsing node ".$nodeCount." of file ".$relPath."\n";
+            }
+        }
+    }
+}
+
+exit($success ? 0 : 1);

--- a/bin/ci_neon_lint
+++ b/bin/ci_neon_lint
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// this CLI script will lint all the .neon files in the repository
+
+$path = realpath(__DIR__ . '/../');
+$it = new RecursiveDirectoryIterator($path);
+$it = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::LEAVES_ONLY);
+$it = new RegexIterator($it, '~\.neon$~');
+
+$success = true;
+foreach ($it as $file) {
+    /** @var SplFileInfo $file */
+    if (strpos($file->getRealPath(), '/vendor/') !== false) {
+        continue;
+    }
+
+    try {
+        $content = file_get_contents($file->getRealPath());
+        Nette\Neon\Neon::decode($content);
+    } catch (Nette\Neon\Exception $e) {
+        $success = false;
+        $relPath = str_replace($path . DIRECTORY_SEPARATOR, '', $file->getRealPath());
+        echo "Failed parsing ".$relPath."\n";
+    }
+}
+
+exit($success ? 0 : 1);

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,11 @@
   "require-dev": {
     "captainhook/captainhook": "^5.10.4",
     "captainhook/plugin-composer": "^5.3.2",
+    "league/commonmark": "^1.4",
     "madewithlove/license-checker": "^0.10.0",
     "magento/framework": ">=102.0.0",
     "mikey179/vfsstream": "^1.6.10",
+    "nette/neon": "^3.3.1",
     "nikic/php-parser": "^4.13.1",
     "phpstan/extension-installer": "^1.1.0",
     "phpstan/phpstan-phpunit": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ddfe96390a9a0fc58870028af45d201",
+    "content-hash": "368c8430ebd2bd3e4e61fb0763f61a3c",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -2862,6 +2862,107 @@
             "time": "2021-12-17T11:25:32+00:00"
         },
         {
+            "name": "league/commonmark",
+            "version": "1.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/commonmark.git",
+                "reference": "c4228d11e30d7493c6836d20872f9582d8ba6dcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c4228d11e30d7493c6836d20872f9582d8ba6dcf",
+                "reference": "c4228d11e30d7493c6836d20872f9582d8ba6dcf",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "scrutinizer/ocular": "1.7.*"
+            },
+            "require-dev": {
+                "cebe/markdown": "~1.0",
+                "commonmark/commonmark.js": "0.29.2",
+                "erusev/parsedown": "~1.0",
+                "ext-json": "*",
+                "github/gfm": "0.29.0",
+                "michelf/php-markdown": "~1.4",
+                "mikehaertl/php-shellcommand": "^1.4",
+                "phpstan/phpstan": "^0.12.90",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
+                "scrutinizer/ocular": "^1.5",
+                "symfony/finder": "^4.2"
+            },
+            "bin": [
+                "bin/commonmark"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\CommonMark\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and Github-Flavored Markdown (GFM)",
+            "homepage": "https://commonmark.thephpleague.com",
+            "keywords": [
+                "commonmark",
+                "flavored",
+                "gfm",
+                "github",
+                "github-flavored",
+                "markdown",
+                "md",
+                "parser"
+            ],
+            "support": {
+                "docs": "https://commonmark.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/commonmark/issues",
+                "rss": "https://github.com/thephpleague/commonmark/releases.atom",
+                "source": "https://github.com/thephpleague/commonmark"
+            },
+            "funding": [
+                {
+                    "url": "https://enjoy.gitstore.app/repositories/thephpleague/commonmark",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-17T17:13:23+00:00"
+        },
+        {
             "name": "madewithlove/license-checker",
             "version": "v0.10.0",
             "source": {
@@ -3216,6 +3317,74 @@
                 }
             ],
             "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/54b287d8c2cdbe577b02e28ca1713e275b05ece2",
+                "reference": "54b287d8c2cdbe577b02e28ca1713e275b05ece2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.7"
+            },
+            "bin": [
+                "bin/neon-lint"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "https://ne-on.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/neon/issues",
+                "source": "https://github.com/nette/neon/tree/v3.3.2"
+            },
+            "time": "2021-11-25T15:57:41+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/docs/features.md
+++ b/docs/features.md
@@ -42,7 +42,7 @@ Since Magento framework version 100.1.0 entities must not be responsible for the
 be used to persist entities.
 
 To disable this rule add the following code to your `phpstan.neon` configuration file:
-```
+```neon
 parameters:
     magento:
         checkServiceContracts: false
@@ -54,7 +54,7 @@ Since Magento framework version 101.0.0 Collections should be used directly via 
 `\Magento\Framework\Model\AbstractModel::getCollection()` directly.
 
 To disable this rule add the following code to your `phpstan.neon` configuration file:
-```
+```neon
 parameters:
     magento:
         checkCollectionViaFactory: false


### PR DESCRIPTION
To make sure the neon configuration files like `extension.neon` or `phpstan.neon` are valid, check those files in the CI pipeline.

Additionally, also check the neon configuration snippets in the Markdown files to make sure the syntax is correct.