### PR TITLE
Rework extension attribute handling for standalone modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,10 @@
     }
   ],
   "require": {
-    "php": "^7.2.0 | ^8.0.0",
+    "php": "^7.2.0 || ^8.0.0",
     "ext-dom": "*",
-    "laminas/laminas-code": "~3.3.0 | ~3.4.1 | ~3.5.1",
+    "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1",
+    "symfony/finder": "^3.0 || ^4.0 || ^5.0",
     "phpstan/phpstan": "^1.2.0"
   },
   "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "php": "^7.2.0 || ^8.0.0",
     "ext-dom": "*",
     "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1",
-    "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-    "phpstan/phpstan": "^1.2.0"
+    "phpstan/phpstan": "^1.2.0",
+    "symfony/finder": "^3.0 || ^4.0 || ^5.0"
   },
   "conflict": {
     "magento/framework": "<102.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "368c8430ebd2bd3e4e61fb0763f61a3c",
+    "content-hash": "3bb36f759856ae6f4fd8fea93e207462",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -265,6 +265,219 @@
                 }
             ],
             "time": "2021-11-18T14:09:01+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-12T14:48:14+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/d2f29dac98e96a98be467627bd49c2efb1bc2590",
+                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-28T15:25:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
         }
     ],
     "packages-dev": [
@@ -7130,73 +7343,6 @@
             "time": "2021-12-01T16:25:34+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-07-12T14:48:14+00:00"
-        },
-        {
             "name": "symfony/error-handler",
             "version": "v4.4.34",
             "source": {
@@ -7490,69 +7636,6 @@
                 }
             ],
             "time": "2021-10-28T13:39:27+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v5.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/d2f29dac98e96a98be467627bd49c2efb1bc2590",
-                "reference": "d2f29dac98e96a98be467627bd49c2efb1bc2590",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-11-28T15:25:38+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -8293,89 +8376,6 @@
                 }
             ],
             "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -9432,7 +9432,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.0 | ^8.0.0",
+        "php": "^7.2.0 || ^8.0.0",
         "ext-dom": "*"
     },
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bb36f759856ae6f4fd8fea93e207462",
+    "content-hash": "2c70aa65d06f9c0176bebde81642857d",
     "packages": [
         {
             "name": "laminas/laminas-code",

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,6 +31,17 @@ to be able to let the magic method calls return proper types.
 ## Extension attributes
 This PHPStan extension supports [extension attributes](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/extension_attributes/adding-attributes.html) by parsing the `extension_attributes.xml` files.
 
+By default, all `extension_attributes.xml` recursively  found in the current working directory will be taken into account.
+Current working directory means the directory in which your `phpstan.neon` file resides. If you need to change this behavior,
+you can define a custom path by pointing the `magentoRoot` parameter to a different directory.
+
+To disable this rule add the following code to your `phpstan.neon` configuration file:
+```neon
+parameters:
+    magento:
+        magentoRoot: /tmp/my/other/dir
+```
+
 ## PHPStan rules
 
 The following rules are available to run checks against your codebase, e.g. if your implementation adheres to the

--- a/extension.neon
+++ b/extension.neon
@@ -71,10 +71,14 @@ services:
 			cache: @autoloaderCache
 		tags:
 			- phpstan.magento.autoloader
+	extensionAttributeDataProvider:
+		class: bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider
+		arguments:
+			magentoRoot: %magento.magentoRoot%
 	extensionInterfaceAutoloader:
 		class: bitExpert\PHPStan\Magento\Autoload\ExtensionInterfaceAutoloader
 		arguments:
 			cache: @autoloaderCache
-			magentoRoot: %magento.magentoRoot%
+			attributeDataProvider: @extensionAttributeDataProvider
 		tags:
 			- phpstan.magento.autoloader

--- a/extension.neon
+++ b/extension.neon
@@ -75,10 +75,15 @@ services:
 		class: bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider
 		arguments:
 			magentoRoot: %magento.magentoRoot%
+	classLoaderProvider:
+		class: bitExpert\PHPStan\Magento\Autoload\DataProvider\ClassLoaderProvider
+		arguments:
+			magentoRoot: %magento.magentoRoot%
 	extensionInterfaceAutoloader:
 		class: bitExpert\PHPStan\Magento\Autoload\ExtensionInterfaceAutoloader
 		arguments:
 			cache: @autoloaderCache
 			attributeDataProvider: @extensionAttributeDataProvider
+			classLoaderProvider: @classLoaderProvider
 		tags:
 			- phpstan.magento.autoloader

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,9 +44,6 @@ parameters:
             message: '~is not covered by backward compatibility promise.~'
             path: tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
         -
-            message: '~Parameter #1 $argument of class ReflectionClass constructor expects class-string<UncachedExtensionInterface>|UncachedExtensionInterface, string given~'
-            path: tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
-        -
             message: '~bitExpert\\PHPStan\\Magento\\Rules\\Helper\\SampleModel::__construct\(\) does not call parent constructor~'
             path: tests/bitExpert/PHPStan/Magento/Rules/Helper/SampleModel.php
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,6 +44,9 @@ parameters:
             message: '~is not covered by backward compatibility promise.~'
             path: tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
         -
+            message: '~Parameter #1 $argument of class ReflectionClass constructor expects class-string<UncachedExtensionInterface>|UncachedExtensionInterface, string given~'
+            path: tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
+        -
             message: '~bitExpert\\PHPStan\\Magento\\Rules\\Helper\\SampleModel::__construct\(\) does not call parent constructor~'
             path: tests/bitExpert/PHPStan/Magento/Rules/Helper/SampleModel.php
         -

--- a/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ClassLoaderProvider.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ClassLoaderProvider.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload\DataProvider;
+
+use Composer\Autoload\ClassLoader;
+
+class ClassLoaderProvider
+{
+    /**
+     * @var ClassLoader
+     */
+    private $composer;
+
+    /**
+     * ClassLoaderProvider constructor.
+     *
+     * @param string $magentoRoot
+     */
+    public function __construct(string $magentoRoot)
+    {
+        $this->composer = new ClassLoader($magentoRoot.'/vendor');
+        $autoloadFile = $magentoRoot.'/vendor/composer/autoload_namespaces.php';
+        if (is_file($autoloadFile)) {
+            $map = require $autoloadFile;
+            foreach ($map as $namespace => $path) {
+                $this->composer->set($namespace, $path);
+            }
+        }
+
+        $autoloadFile = $magentoRoot.'/vendor/composer/autoload_psr4.php';
+        if (is_file($autoloadFile)) {
+            $map = require $autoloadFile;
+            foreach ($map as $namespace => $path) {
+                $this->composer->setPsr4($namespace, $path);
+            }
+        }
+
+        $autoloadFile = $magentoRoot.'/vendor/composer/autoload_classmap.php';
+        if (is_file($autoloadFile)) {
+            $classMap = require $autoloadFile;
+            if (is_array($classMap)) {
+                $this->composer->addClassMap($classMap);
+            }
+        }
+    }
+
+    /**
+     * Check if the given class/interface/tait exists in the defined scope.
+     *
+     * @param string $classyConstructName
+     * @return bool
+     */
+    public function exists(string $classyConstructName): bool
+    {
+        return $this->composer->findFile($classyConstructName) !== false;
+    }
+}

--- a/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProvider.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProvider.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload\DataProvider;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+class ExtensionAttributeDataProvider
+{
+    /**
+     * @var string
+     */
+    private $magentoRoot;
+    /**
+     * @var DOMDocument[]|null
+     */
+    private $xmlDocs;
+
+    /**
+     * ExtensionAttributeDataProvider constructor.
+     *
+     * @param string $magentoRoot
+     */
+    public function __construct(string $magentoRoot)
+    {
+        $this->magentoRoot = $magentoRoot;
+    }
+
+    /**
+     * Returns
+     * @param string $sourceInterface
+     * @return array<string, string>
+     */
+    public function getAttributesForInterface(string $sourceInterface): array
+    {
+        $return = [];
+
+        foreach ($this->getExtensionAttributesXmlDocs() as $doc) {
+            $xpath = new DOMXPath($doc);
+            $attrs = $xpath->query(
+                "//extension_attributes[@for=\"${sourceInterface}\"]/attribute",
+                $doc->documentElement
+            );
+
+            if ($attrs === false) {
+                continue;
+            }
+
+            foreach ($attrs as $attr) {
+                /** @var DOMElement $attr */
+                $propertyName = $this->getAttrName($attr);
+                $type = $this->getAttrType($attr);
+                $return[$propertyName] = $type;
+            }
+        }
+
+        return $return;
+    }
+
+
+    /**
+     * Create a generator which creates DOM documents for every extension attributes XML file found.
+     *
+     * @return DOMDocument[]
+     */
+    protected function getExtensionAttributesXmlDocs(): array
+    {
+        if (is_array($this->xmlDocs)) {
+            return $this->xmlDocs;
+        }
+
+        $finder = Finder::create()
+            ->files()
+            ->in($this->magentoRoot)
+            ->name('extension_attributes.xml')
+            ->filter(static function (SplFileInfo $file) {
+                // ignore any files not located in an etc directory to exclude e.g. test data
+                return $file->isFile() && (bool) preg_match('#etc/extension_attributes.xml$#', $file->getPathname());
+            });
+
+        $this->xmlDocs = [];
+        foreach ($finder as $item) {
+            /** @var SplFileInfo $item */
+            $doc = new DOMDocument();
+            $doc->loadXML($item->getContents());
+            $this->xmlDocs[] = $doc;
+        }
+
+        return $this->xmlDocs;
+    }
+
+    /**
+     * Extracts and formats the attribute type out of the given DOM element.
+     *
+     * @param DOMElement $attr
+     * @return string
+     */
+    protected function getAttrType(DOMElement $attr): string
+    {
+        $type = $attr->getAttribute('type');
+        $cleanType = str_replace('[]', '', $type);
+
+        $primitiveTypes = ['float', 'int', 'string', 'bool', 'boolean'];
+        return in_array(strtolower($cleanType), $primitiveTypes, true) ? $cleanType : '\\'.$cleanType;
+    }
+
+    /**
+     * Extracts and formats the attribute name out of the given DOM element
+     * @param DOMElement $attr
+     * @return string
+     */
+    protected function getAttrName(DOMElement $attr): string
+    {
+        // see Magento\Framework\Api\SimpleDataObjectConverter::snakeCaseToCamelCase()
+        $attrName = $attr->getAttribute('code');
+        $attrName = str_replace('_', '', ucwords($attrName, '_'));
+        return lcfirst($attrName);
+    }
+}

--- a/src/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloader.php
@@ -12,61 +12,40 @@ declare(strict_types=1);
 
 namespace bitExpert\PHPStan\Magento\Autoload;
 
+use bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
 use Laminas\Code\Generator\DocBlock\Tag\ReturnTag;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\InterfaceGenerator;
 use Laminas\Code\Generator\MethodGenerator;
-use Magento\Framework\Api\SimpleDataObjectConverter;
-use Magento\Framework\App\DeploymentConfig;
-use Magento\Framework\App\DeploymentConfig\Reader as DeploymentConfigReader;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Component\ComponentRegistrar;
-use Magento\Framework\Config\File\ConfigFilePool;
-use Magento\Framework\Filesystem;
-use Magento\Framework\Filesystem\Driver\File as FileDriver;
-use Magento\Framework\Module\Declaration\Converter\Dom as ModuleDeclarationDom;
-use Magento\Framework\Module\ModuleList;
-use Magento\Framework\Module\ModuleList\Loader;
-use Magento\Framework\Xml\Parser as XmlParser;
 use PHPStan\Cache\Cache;
-use Symfony\Component\Finder\Finder;
 
 class ExtensionInterfaceAutoloader implements Autoloader
 {
-    private $moduleList;
-
-    private $componentRegistrar;
-
+    /**
+     * @var Cache
+     */
     private $cache;
+    /**
+     * @var ExtensionAttributeDataProvider
+     */
+    private $attributeDataProvider;
 
-    /** @var \DOMDocument[]|null */
-    private $xmlDocs;
-
-    public function __construct(Cache $cache, string $magentoRoot)
+    /**
+     * ExtensionInterfaceAutoloader constructor.
+     *
+     * @param Cache $cache
+     * @param ExtensionAttributeDataProvider $attributeDataProvider
+     */
+    public function __construct(Cache $cache, ExtensionAttributeDataProvider $attributeDataProvider)
     {
         $this->cache = $cache;
-        $this->componentRegistrar = new ComponentRegistrar();
-        $this->moduleList = new ModuleList(
-            new DeploymentConfig(
-                new DeploymentConfigReader(
-                    new DirectoryList($magentoRoot),
-                    new Filesystem\DriverPool(),
-                    new ConfigFilePool()
-                )
-            ),
-            new Loader(
-                new ModuleDeclarationDom(),
-                new XmlParser(),
-                $this->componentRegistrar,
-                new FileDriver()
-            )
-        );
+        $this->attributeDataProvider = $attributeDataProvider;
     }
 
     public function autoload(string $class): void
     {
-        if (preg_match('/ExtensionInterface$/', $class) !== 1) {
+        if (preg_match('#ExtensionInterface$#', $class) !== 1) {
             return;
         }
 
@@ -80,7 +59,7 @@ class ExtensionInterfaceAutoloader implements Autoloader
             }
         }
 
-        require_once $cachedFilename;
+        require_once($cachedFilename);
     }
 
     /**
@@ -97,119 +76,44 @@ class ExtensionInterfaceAutoloader implements Autoloader
          */
         $sourceInterface = rtrim(substr($interfaceName, 0, -1 * strlen('ExtensionInterface')), '\\') . 'Interface';
 
-        // Magento only creates extension attribute interfaces for existing interfaces; retain that logic
-        if (!interface_exists($sourceInterface)) {
-            throw new \InvalidArgumentException("${sourceInterface} does not exist and has no extension interface");
-        }
-
         $generator = new InterfaceGenerator();
         $generator
             ->setName($interfaceName)
-            ->setImplementedInterfaces([\Magento\Framework\Api\ExtensionAttributesInterface::class]);
+            ->setImplementedInterfaces(['\Magento\Framework\Api\ExtensionAttributesInterface']);
 
-        foreach ($this->getExtensionAttributesXmlDocs() as $doc) {
-            $xpath = new \DOMXPath($doc);
-            $attrs = $xpath->query(
-                "//extension_attributes[@for=\"${sourceInterface}\"]/attribute",
-                $doc->documentElement
+        $attrs = $this->attributeDataProvider->getAttributesForInterface($sourceInterface);
+        foreach ($attrs as $propertyName => $type) {
+            /**
+             * Generate getters and setters for each extension attribute
+             *
+             * @see \Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator::_getClassMethods
+             */
+
+            $generator->addMethodFromGenerator(
+                MethodGenerator::fromArray([
+                    'name' => 'get' . ucfirst($propertyName),
+                    'docblock' => DocBlockGenerator::fromArray([
+                        'tags' => [
+                            new ReturnTag([$type, 'null']),
+                        ],
+                    ]),
+                ])
             );
-
-            if ($attrs === false) {
-                continue;
-            }
-
-            /** @var \DOMElement $attr */
-            foreach ($attrs as $attr) {
-                /**
-                 * Generate getters and setters for each extension attribute
-                 *
-                 * @see \Magento\Framework\Api\Code\Generator\ExtensionAttributesGenerator::_getClassMethods
-                 */
-                $propertyName = SimpleDataObjectConverter::snakeCaseToCamelCase($attr->getAttribute('code'));
-                $type = $this->getAttrType($attr);
-
-                $generator->addMethodFromGenerator(
-                    MethodGenerator::fromArray([
-                        'name' => 'get' . ucfirst($propertyName),
-                        'docblock' => DocBlockGenerator::fromArray([
-                            'tags' => [
-                                new ReturnTag([$type, 'null']),
-                            ],
-                        ]),
+            $generator->addMethodFromGenerator(
+                MethodGenerator::fromArray([
+                    'name' => 'set' . ucfirst($propertyName),
+                    'parameters' => [$propertyName],
+                    'docblock' => DocBlockGenerator::fromArray([
+                        'tags' => [
+                            new ParamTag($propertyName, [$type]),
+                            new ReturnTag('$this')
+                        ]
                     ])
-                );
-                $generator->addMethodFromGenerator(
-                    MethodGenerator::fromArray([
-                        'name' => 'set' . ucfirst($propertyName),
-                        'parameters' => [$propertyName],
-                        'docblock' => DocBlockGenerator::fromArray([
-                            'tags' => [
-                                new ParamTag(
-                                    $propertyName,
-                                    [
-                                        $type
-                                    ]
-                                ),
-                                new ReturnTag(
-                                    '$this'
-                                )
-                            ]
-                        ])
-                    ])
-                );
-            }
+                ])
+            );
         }
 
         return "<?php\n\n" . $generator->generate();
-    }
-
-    /**
-     * Create a generator which creates DOM documents for every extension attributes XML file in enabled modules
-     *
-     * @return \DOMDocument[]
-     */
-    private function getExtensionAttributesXmlDocs(): array
-    {
-        if (is_array($this->xmlDocs)) {
-            return $this->xmlDocs;
-        }
-
-        $enabledModuleDirs = array_filter(
-            $this->componentRegistrar->getPaths(ComponentRegistrar::MODULE),
-            function ($moduleName) {
-                return $this->moduleList->has($moduleName);
-            },
-            ARRAY_FILTER_USE_KEY
-        );
-
-        $finder = Finder::create()
-            ->files()
-            ->in(array_map(function ($dir) {
-                return $dir . '/etc';
-            }, $enabledModuleDirs))
-            ->name('extension_attributes.xml');
-
-        $this->xmlDocs = [];
-        foreach ($finder as $item) {
-            $doc = new \DOMDocument();
-            $doc->loadXML($item->getContents());
-            $this->xmlDocs[] = $doc;
-        }
-
-        return $this->xmlDocs;
-    }
-
-    /**
-     * @param \DOMElement $attr
-     *
-     * @return string
-     */
-    protected function getAttrType(\DOMElement $attr): string
-    {
-        $type = $attr->getAttribute('type');
-        $cleanType = str_replace('[]', '', $type);
-        return class_exists($cleanType) || interface_exists($cleanType) || trait_exists($cleanType)
-            ? '\\' . $type : $type;
     }
 
     public function register(): void

--- a/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ClassLoaderProviderUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ClassLoaderProviderUnitTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload\DataProvider;
+
+use PHPUnit\Framework\TestCase;
+
+class ClassLoaderProviderUnitTest extends TestCase
+{
+    /**
+     * @var ClassLoaderProvider
+     */
+    private $dataprovider;
+
+    protected function setUp(): void
+    {
+        $this->dataprovider = new ClassLoaderProvider(__DIR__ . '/../../../../../../');
+    }
+
+    /**
+     * @test
+     */
+    public function returnsTrueForClassesFound(): void
+    {
+        static::assertTrue($this->dataprovider->exists(ClassLoaderProviderUnitTest::class));
+    }
+
+    /**
+     * @test
+     */
+    public function returnsFalseWhenClassNotFound(): void
+    {
+        static::assertFalse($this->dataprovider->exists('SomeOtherClass'));
+    }
+}

--- a/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProviderUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProviderUnitTest.php
@@ -47,7 +47,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(1, $attrs);
         static::assertSame('string', $attrs['attr']);
     }
@@ -73,7 +72,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Some\Random\Api\Data\SampleInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(0, $attrs);
     }
 
@@ -114,7 +112,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(2, $attrs);
         static::assertSame('string', $attrs['attr']);
         static::assertSame('string', $attrs['attr2']);
@@ -145,7 +142,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(0, $attrs);
     }
 
@@ -174,7 +170,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(5, $attrs);
         static::assertSame('float', $attrs['attr']);
         static::assertSame('int', $attrs['attr2']);
@@ -204,7 +199,6 @@ XML
         $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
         $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
 
-        static::assertIsArray($attrs);
         static::assertCount(1, $attrs);
         static::assertSame('\Magento\Quote\Api\Data\CartInterface', $attrs['attr']);
     }

--- a/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProviderUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProviderUnitTest.php
@@ -1,0 +1,211 @@
+<?php
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload\DataProvider;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+class ExtensionAttributeDataProviderUnitTest extends TestCase
+{
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $root;
+
+    protected function setUp(): void
+    {
+        $this->root = vfsStream::setup('test');
+    }
+
+    /**
+     * @test
+     */
+    public function returnsArrayWhenAttrsForInterfaceExist(): void
+    {
+        vfsStream::create([
+            'etc' => [
+                'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="attr" type="string"/>
+    </extension_attributes>
+</config>
+XML
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(1, $attrs);
+        static::assertSame('string', $attrs['attr']);
+    }
+
+    /**
+     * @test
+     */
+    public function returnsEmptyArrayWhenNoAttrsForInterfaceExist(): void
+    {
+        vfsStream::create([
+            'etc' => [
+                'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="attr" type="string"/>
+    </extension_attributes>
+</config>
+XML
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Some\Random\Api\Data\SampleInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(0, $attrs);
+    }
+
+    /**
+     * @test
+     */
+    public function loadsAndMergesAttributesFromDifferentSourceFiles(): void
+    {
+        vfsStream::create([
+            'etc' => [
+                'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="attr" type="string"/>
+    </extension_attributes>
+</config>
+XML
+            ],
+            'vendor' => [
+                'vendor1' => [
+                    'package1' => [
+                        'etc' => [
+                            'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+<extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+    <attribute code="attr2" type="string"/>
+</extension_attributes>
+</config>
+XML
+                        ]
+                    ]
+                ]
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(2, $attrs);
+        static::assertSame('string', $attrs['attr']);
+        static::assertSame('string', $attrs['attr2']);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresFilesInNonEtcDir(): void
+    {
+        vfsStream::create([
+            'test' => [
+                'My' => [
+                    'Namespace' => [
+                        'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+<extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+    <attribute code="attr2" type="string"/>
+</extension_attributes>
+</config>
+XML
+                    ]
+                ]
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(0, $attrs);
+    }
+
+    /**
+     * @test
+     */
+    public function primitiveTypesAreReturnedAsIs(): void
+    {
+        vfsStream::create([
+            'etc' => [
+                'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="attr" type="float"/>
+        <attribute code="attr2" type="int"/>
+        <attribute code="attr3" type="string"/>
+        <attribute code="attr4" type="bool"/>
+        <attribute code="attr5" type="boolean"/>
+    </extension_attributes>
+</config>
+XML
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(5, $attrs);
+        static::assertSame('float', $attrs['attr']);
+        static::assertSame('int', $attrs['attr2']);
+        static::assertSame('string', $attrs['attr3']);
+        static::assertSame('bool', $attrs['attr4']);
+        static::assertSame('boolean', $attrs['attr5']);
+    }
+
+    /**
+     * @test
+     */
+    public function classTypeIsReturnedWithValidNamespace(): void
+    {
+        vfsStream::create([
+            'etc' => [
+                'extension_attributes.xml' => <<<'XML'
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="attr" type="Magento\Quote\Api\Data\CartInterface"/>
+    </extension_attributes>
+</config>
+XML
+            ]
+        ], $this->root);
+
+        $dataprovider = new ExtensionAttributeDataProvider($this->root->url());
+        $attrs = $dataprovider->getAttributesForInterface('Magento\Sales\Api\Data\OrderInterface');
+
+        static::assertIsArray($attrs);
+        static::assertCount(1, $attrs);
+        static::assertSame('\Magento\Quote\Api\Data\CartInterface', $attrs['attr']);
+    }
+}

--- a/tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
@@ -2,136 +2,55 @@
 
 namespace bitExpert\PHPStan\Magento\Autoload;
 
-use bitExpert\PHPStan\Magento\Autoload\Cache\FileCacheStorage;
-use Magento\Framework\Component\ComponentRegistrar;
-use org\bovigo\vfs\vfsStream;
+use bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider;
 use PHPStan\Cache\Cache;
 use PHPStan\Cache\CacheStorage;
 use PHPUnit\Framework\TestCase;
 
 class ExtensionInterfaceAutoloaderUnitTest extends TestCase
 {
-    /** @var \org\bovigo\vfs\vfsStreamDirectory */
-    private $root;
+    /**
+     * @var CacheStorage|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $storage;
+    /**
+     * @var ExtensionAttributeDataProvider|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $dataProvider;
+    /**
+     * @var ExtensionInterfaceAutoloader
+     */
+    private $autoloader;
 
     protected function setUp(): void
     {
-        $this->root = vfsStream::setup('test');
+        $this->storage = $this->createMock(CacheStorage::class);
+        $this->dataProvider = $this->createMock(ExtensionAttributeDataProvider::class);
+        $this->autoloader = new ExtensionInterfaceAutoloader(new Cache($this->storage), $this->dataProvider);
     }
 
     /**
      * @test
      */
-    public function autoloadIgnoresClassesWithoutExtensionInterface(): void
+    public function autoloaderIgnoresClassesWithoutExtensionInterfacePostfix(): void
     {
-        $cacheStorage = $this->getMockBuilder(CacheStorage::class)->getMock();
-        $autoloader = new ExtensionInterfaceAutoloader(
-            new Cache($cacheStorage),
-            $this->root->url()
-        );
-        $cacheStorage->expects(self::never())->method('load');
-        $autoloader->autoload('ExtensionInterfaceNotAtEnd');
+        $this->storage->expects(self::never())
+            ->method('load');
+
+        $this->autoloader->autoload('SomeClass');
     }
 
     /**
      * @test
      */
-    public function autoloadUsesCachedFileWhenFound(): void
+    public function autoloaderUsesCachedFileWhenFound(): void
     {
-        $interfaceName = 'CachedExtensionInterface';
-        $cache = new Cache(new FileCacheStorage($this->root->url() . '/tmp/cache/PHPStan'));
-        $cache->save($interfaceName, '', "<?php interface ${interfaceName} {}");
-        $autoloader = new ExtensionInterfaceAutoloader($cache, $this->root->url());
+        $this->storage->expects(self::once())
+            ->method('load')
+            ->willReturn(__DIR__ . '/HelperExtensionInterface.php');
 
-        static::assertFalse(interface_exists($interfaceName));
-        $autoloader->autoload($interfaceName);
-        static::assertTrue(interface_exists($interfaceName));
-    }
+        $this->autoloader->autoload(HelperExtensionInterface::class);
 
-    /**
-     * @test
-     */
-    public function autoloadDoesNotGenerateInterfaceWhenNoAttributesExist(): void
-    {
-        $interfaceName = 'NonExistentExtensionInterface';
-        $cache = new Cache(new FileCacheStorage($this->root->url() . '/tmp/cache/PHPStan'));
-        $autoloader = new ExtensionInterfaceAutoloader($cache, $this->root->url());
-
-        $autoloader->autoload($interfaceName);
-        static::assertFalse(interface_exists($interfaceName));
-    }
-
-    /**
-     * @test
-     */
-    public function autoloadGeneratesInterfaceWhenNotCached(): void
-    {
-        $interfaceName = 'UncachedExtensionInterface';
-        vfsStream::create([
-            'interface.php' => '<?php interface UncachedInterface {}',
-            'app' => [
-                'etc' => [
-                    'config.php' => <<<PHP
-<?php return [
-    'modules' => [
-        'Module_Name' => 1
-    ]
-];
-PHP
-                ],
-                'code' => [
-                    'Module_Name' => [
-                        'etc' => [
-                            'extension_attributes.xml' => <<<'XML'
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
-    <extension_attributes for="UncachedInterface">
-        <attribute code="attr" type="string"/>
-    </extension_attributes>
-</config>
-XML
-                        ]
-                    ]
-                ]
-            ],
-        ], $this->root);
-
-        ComponentRegistrar::register(
-            ComponentRegistrar::MODULE,
-            'Module_Name',
-            $this->root->url() . '/app/code/Module_Name'
-        );
-
-        $autoloader = new ExtensionInterfaceAutoloader(
-            new Cache(new FileCacheStorage($this->root->url() . '/tmp/cache/PHPStan')),
-            $this->root->url()
-        );
-
-        require $this->root->url() . '/interface.php';
-
-        $autoloader->autoload($interfaceName);
-        static::assertTrue(interface_exists($interfaceName));
-        $interfaceReflection = new \ReflectionClass($interfaceName);
-        try {
-            $getAttrReflection = $interfaceReflection->getMethod('getAttr');
-            $docComment = $getAttrReflection->getDocComment();
-            if (!is_string($docComment)) {
-                throw new \ReflectionException();
-            }
-            static::assertStringContainsString('@return string|null', $docComment);
-        } catch (\ReflectionException $e) {
-            static::fail('Could not find expected method getAttr on generated interface');
-        }
-
-        try {
-            $setAttrReflection = $interfaceReflection->getMethod('setAttr');
-            $docComment = $setAttrReflection->getDocComment();
-            if (!is_string($docComment)) {
-                throw new \ReflectionException();
-            }
-            static::assertStringContainsString('@param string $attr', $docComment);
-        } catch (\ReflectionException $e) {
-            static::fail('Could not find expected generated method setAttr on generated interface');
-        }
+        self::assertTrue(interface_exists(HelperExtensionInterface::class, false));
     }
 }

--- a/tests/bitExpert/PHPStan/Magento/Autoload/HelperExtensionInterface.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/HelperExtensionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the phpstan-magento package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace bitExpert\PHPStan\Magento\Autoload;
+
+/**
+ * Dummy attribute extension interface that can be loaded via the Autoloader in the test cases.
+ */
+interface HelperExtensionInterface extends \Magento\Framework\Api\ExtensionAttributesInterface
+{
+}

--- a/tests/bitExpert/PHPStan/Magento/Autoload/RegistrationUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/RegistrationUnitTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace bitExpert\PHPStan\Magento\Autoload;
 
+use bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider;
 use PHPStan\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 
@@ -49,7 +50,7 @@ class RegistrationUnitTest extends TestCase
             [new MockAutoloader()],
             [new ProxyAutoloader($cache)],
             [new TestFrameworkAutoloader()],
-            [new ExtensionInterfaceAutoloader($cache, '.')]
+            [new ExtensionInterfaceAutoloader($cache, new ExtensionAttributeDataProvider('.'))]
         ];
     }
 }

--- a/tests/bitExpert/PHPStan/Magento/Autoload/RegistrationUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/RegistrationUnitTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace bitExpert\PHPStan\Magento\Autoload;
 
+use bitExpert\PHPStan\Magento\Autoload\DataProvider\ClassLoaderProvider;
 use bitExpert\PHPStan\Magento\Autoload\DataProvider\ExtensionAttributeDataProvider;
 use PHPStan\Cache\Cache;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +51,11 @@ class RegistrationUnitTest extends TestCase
             [new MockAutoloader()],
             [new ProxyAutoloader($cache)],
             [new TestFrameworkAutoloader()],
-            [new ExtensionInterfaceAutoloader($cache, new ExtensionAttributeDataProvider('.'))]
+            [new ExtensionInterfaceAutoloader(
+                $cache,
+                new ExtensionAttributeDataProvider(__DIR__),
+                new ClassLoaderProvider(__DIR__)
+            )]
         ];
     }
 }


### PR DESCRIPTION
Fixes #174

In contrast to my plan outlined in #174, I took a different route as I realized that it can be problematic to depend on Magento framework classes (loading and analyzing framework classes at the same time). Additionally, it was not possible to install PHPStan and this extension in a different directory as then the Composer autoloader would not work for the project-specific classes (e.g. for the class_exists, interface_exists, and trait_exists checks).

What happens now is that all `extension_attributes.xml` found in `etc` directories are loaded recursively and evaluated regardless of whether the module is active or not. By default, the current working directory (the directory you placed your `phpstan.neon` file in) will be used as a starting point. If you need to change that, you can configure the `magentoRoot` parameter and point it to a different location.
To deal with inactive modules, we could either add a directory blacklist configuration or add some logic to evaluate the `config.php` settings and only take active modules into account.