### PR TITLE
Do not yet install PHPStan 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "^7.2.0 || ^8.1.0",
     "ext-dom": "*",
     "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1 || ~4.5.0",
-    "phpstan/phpstan": "^1.6.2",
+    "phpstan/phpstan": "^1.6.2 <1.7.0",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0 || ^6.0"
   },
   "conflict": {


### PR DESCRIPTION
Restrict the PHPStan version to 1.6 max due to compatibility problems with PHPStan 1.7 (see #243).
