### PR TITLE
Adds PHP 8.2 / Magento 2.4.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": "^7.2.0 || ^8.1.0",
     "ext-dom": "*",
-    "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1 || ~4.5.0 || ~4.5.2",
+    "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1 || ^4.5",
     "phpstan/phpstan": "~1.9.2",
     "symfony/finder": "^3.0 || ^4.0 || ^5.0 || ^6.0"
   },

--- a/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProvider.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/DataProvider/ExtensionAttributeDataProvider.php
@@ -50,7 +50,7 @@ class ExtensionAttributeDataProvider
         foreach ($this->getExtensionAttributesXmlDocs() as $doc) {
             $xpath = new DOMXPath($doc);
             $attrs = $xpath->query(
-                "//extension_attributes[@for=\"${sourceInterface}\"]/attribute",
+                sprintf('//extension_attributes[@for="%s"]/attribute', $sourceInterface),
                 $doc->documentElement
             );
 

--- a/src/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloader.php
@@ -90,7 +90,9 @@ class ExtensionInterfaceAutoloader implements Autoloader
 
         // Magento only creates extension attribute interfaces for existing interfaces; retain that logic
         if (!$this->classLoaderProvider->exists($sourceInterface)) {
-            throw new \InvalidArgumentException("${sourceInterface} does not exist and has no extension interface");
+            throw new \InvalidArgumentException(
+                sprintf('%s does not exist and has no extension interface', $sourceInterface)
+            );
         }
 
         $generator = new InterfaceGenerator();

--- a/tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Autoload/ExtensionInterfaceAutoloaderUnitTest.php
@@ -96,6 +96,7 @@ class ExtensionInterfaceAutoloaderUnitTest extends TestCase
     public function autoloadDoesNotGenerateInterfaceWhenNoAttributesExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('NonExistentInterface does not exist and has no extension interface');
 
         $interfaceName = 'NonExistentExtensionInterface';
 


### PR DESCRIPTION
Things done:
- Allow higher versions of `laminas/laminas-code` to be installed which brings in PHP 8.2 / Magento 2.4.6 support.
- Also replaced PHP 8.2 deprecated syntax.
- Also added test for exception message (wanted to make sure nothing broke by my change)

I hope you don't mind me switching to the `sprintf` function, I like that better than concatenating strings, it looks a bit more readable this way in my opinion.

Fixes #282