### PR TITLE
Add support for symfony/finder 7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "ext-dom": "*",
     "laminas/laminas-code": "~3.3.0 || ~3.4.1 || ~3.5.1 || ^4.5 || ^4.10",
     "phpstan/phpstan": "~1.12.0",
-    "symfony/finder": "^3.0 || ^4.0 || ^5.0 || ^6.0"
+    "symfony/finder": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
   },
   "conflict": {
     "magento/framework": "<102.0.0"


### PR DESCRIPTION
This ensures this tool is compatible to run alongside newer versions of other codestyle tools.