### PR TITLE
fix: error where scopeConfig proxy would get $scopeType = default

### DIFF
--- a/src/bitExpert/PHPStan/Magento/Autoload/ProxyAutoloader.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/ProxyAutoloader.php
@@ -111,7 +111,7 @@ class ProxyAutoloader implements Autoloader
                                 break;
                             default:
                                 if (is_string($parameter->getDefaultValue())) {
-                                    $defaultValue = ' = ' . $parameter->getDefaultValue();
+                                    $defaultValue = ' = \'' . $parameter->getDefaultValue() . '\'';
                                 }
                                 break;
                         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cd139eac-d5aa-49d4-b6a9-dc586dc93b5e)
The following code was being generated when I had a proxyClass on Scope config.

This seems like the correct fix to me