### PR TITLE
Make cache key unique per project (so per current working directory).

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -65,6 +65,7 @@ services:
 		class: bitExpert\PHPStan\Magento\Autoload\Cache\FileCacheStorage
 		arguments:
 			directory: %tmpDir%/cache/PHPStan
+			magentoRoot: %magento.magentoRoot%
 	autoloaderCache:
 		autowired: false
 		class: PHPStan\Cache\Cache

--- a/src/bitExpert/PHPStan/Magento/Autoload/Cache/FileCacheStorage.php
+++ b/src/bitExpert/PHPStan/Magento/Autoload/Cache/FileCacheStorage.php
@@ -22,13 +22,19 @@ class FileCacheStorage implements CacheStorage
     private $directory;
 
     /**
+     * @var string
+     */
+    private $magentoRoot;
+
+    /**
      * FileCacheStorage constructor.
      *
      * @param string $directory
      */
-    public function __construct(string $directory)
+    public function __construct(string $directory, string $magentoRoot)
     {
         $this->directory = $directory;
+        $this->magentoRoot = $magentoRoot;
     }
 
     /**
@@ -73,7 +79,7 @@ class FileCacheStorage implements CacheStorage
      */
     private function getCacheDir(string $key): string
     {
-        $keyHash = sha1($key);
+        $keyHash = sha1(sprintf('%s/%s', $this->magentoRoot, $key));
         $firstDirectory = sprintf('%s/%s', $this->directory, substr($keyHash, 0, 2));
         return sprintf('%s/%s', $firstDirectory, substr($keyHash, 2, 2));
     }


### PR DESCRIPTION
I ran into a weird situation a couple of times where phpstan loaded a Magento extension attribute interface but not with the expected methods being included.

After some deep debugging, it turned out it was loading the generated extension attribute interface from a totally different project, but since it was using the exact same class name as the other project, it used the one generated from the other project instead of generating a new one.

This is unrelated to phpstan's result cache, but instead is coming from the file cache storage this phpstan extension is using.
So I've updated it to also include the `magentoRoot` variable (which is just the current working directory) in the hash it generates for the cache directory.

After some quick testing, I no longer get false positives/negatives anymore when phpstan runs across multiple projects now.

Let me know if this doesn't make sense, and we can further see how we can improve this.
I don't quite like that we only use the first 4 characters of this hash as the chances on collisions are still very high, not sure why that hash was truncated to only 4 characters? Possibly to avoid too long directory names?

----

Temporary workaround until this PR gets approved, for the people interested, if you overwrite the `tmpDir` to something else per project, in your `phpstan.neon` file, that also solves this issue, example:
```neon
parameters:
    tmpDir: %currentWorkingDirectory%/var/phpstan
```