### PR TITLE
Normalises the indentations to tabs and not a mix of spaces and tabs.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -38,9 +38,9 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
-	    class: bitExpert\PHPStan\Magento\Type\ControllerResultFactoryReturnTypeExtension
-	    tags:
-	        - phpstan.broker.dynamicMethodReturnTypeExtension
+		class: bitExpert\PHPStan\Magento\Type\ControllerResultFactoryReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
 		class: bitExpert\PHPStan\Magento\Reflection\Framework\Session\SessionManagerMagicMethodReflectionExtension
 		tags:


### PR DESCRIPTION
Hard to see in the github interface, but in my editor it looked like this before this PR:
<img width="353" height="179" alt="Screenshot 2026-01-28 at 13 09 28" src="https://github.com/user-attachments/assets/1f3941b9-20cd-4b7d-a793-4f0e834a963b" />
