### PR TITLE
Fix build on PHPStan 2.2.3

### DIFF
--- a/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Reflection/Framework/DataObjectMagicMethodReflectionExtensionUnitTest.php
@@ -41,6 +41,8 @@ class DataObjectMagicMethodReflectionExtensionUnitTest extends PHPStanTestCase
         $this->classReflection = $reflectionProvider->getClass(DataObjectHelper::class);
 
         $this->extension = new DataObjectMagicMethodReflectionExtension();
+
+        parent::setUp();
     }
 
     /**

--- a/tests/bitExpert/PHPStan/Magento/Reflection/Framework/Session/SessionManagerMagicMethodReflectionExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Reflection/Framework/Session/SessionManagerMagicMethodReflectionExtensionUnitTest.php
@@ -38,6 +38,8 @@ class SessionManagerMagicMethodReflectionExtensionUnitTest extends PHPStanTestCa
         $reflectionProvider = $this->getContainer()->getService('reflectionProvider');
         $this->classReflection = $reflectionProvider->getClass(SessionManagerHelper::class);
         $this->extension = new SessionManagerMagicMethodReflectionExtension();
+
+        parent::setUp();
     }
 
     /**

--- a/tests/bitExpert/PHPStan/Magento/Type/ControllerResultFactoryReturnTypeExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Type/ControllerResultFactoryReturnTypeExtensionUnitTest.php
@@ -31,6 +31,8 @@ class ControllerResultFactoryReturnTypeExtensionUnitTest extends PHPStanTestCase
     protected function setUp(): void
     {
         $this->extension = new ControllerResultFactoryReturnTypeExtension();
+
+        parent::setUp();
     }
 
     /**

--- a/tests/bitExpert/PHPStan/Magento/Type/ObjectManagerDynamicReturnTypeExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Type/ObjectManagerDynamicReturnTypeExtensionUnitTest.php
@@ -28,6 +28,8 @@ class ObjectManagerDynamicReturnTypeExtensionUnitTest extends PHPStanTestCase
     protected function setUp(): void
     {
         $this->extension = new ObjectManagerDynamicReturnTypeExtension();
+
+        parent::setup();
     }
 
     /**

--- a/tests/bitExpert/PHPStan/Magento/Type/TestFrameworkObjectManagerDynamicReturnTypeExtensionUnitTest.php
+++ b/tests/bitExpert/PHPStan/Magento/Type/TestFrameworkObjectManagerDynamicReturnTypeExtensionUnitTest.php
@@ -42,6 +42,8 @@ class TestFrameworkObjectManagerDynamicReturnTypeExtensionUnitTest extends PHPSt
     protected function setUp(): void
     {
         $this->extension = new TestFrameworkObjectManagerDynamicReturnTypeExtension();
+
+        parent::setUp();
     }
 
     /**


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/5917

```
Error: Missing call to parent::setUp() method.
Error: Missing call to parent::setUp() method.
Error: Missing call to parent::setUp() method.
Error: Missing call to parent::setUp() method.
Error: Missing call to parent::setUp() method.
```