### PR TITLE
Fix CI pipeline by upgrading to more recent Magento versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.1']
-        magento: ['2.4.4', '2.4.5']
+        php-versions: ['8.4']
+        magento: ['2.4.8']
         coveralls: [ false ]
         include:
-          - php-versions: '8.1'
-            magento: '2.4.6'
+          - php-versions: '8.4'
+            magento: '2.4.9'
             operating-system: 'ubuntu-latest'
             coveralls: true
     steps:
@@ -34,17 +34,13 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
 
-      - name: Install Magento 2.4.4
-        if: matrix.magento == '2.4.4'
-        run: composer update --with-dependencies magento/framework:103.0.4 laminas/laminas-code:4.5.1 symfony/yaml symfony/console madewithlove/license-checker
+      - name: Install Magento 2.4.8
+        if: matrix.magento == '2.4.8'
+        run: composer update --with-dependencies magento/framework:103.0.8 laminas/laminas-code:4.17.0 roave/security-advisories symfony/yaml symfony/console madewithlove/license-checker
 
-      - name: Install Magento 2.4.5
-        if: matrix.magento == '2.4.5'
-        run: composer update --with-dependencies magento/framework:103.0.5 laminas/laminas-code:4.5.2 roave/security-advisories symfony/yaml symfony/console madewithlove/license-checker
-
-      - name: Install Magento 2.4.6
-        if: matrix.magento == '2.4.6'
-        run: composer update --with-dependencies magento/framework:103.0.6 laminas/laminas-code:4.10.0 roave/security-advisories symfony/yaml symfony/console madewithlove/license-checker
+      - name: Install Magento 2.4.9
+        if: matrix.magento == '2.4.9'
+        run: composer update --with-dependencies magento/framework:103.0.9 laminas/laminas-code:4.17.0 roave/security-advisories symfony/yaml symfony/console madewithlove/license-checker
 
       - name: Composer license check
         run: composer check-license
@@ -58,7 +54,6 @@ jobs:
           ./bin/ci_markdown_neon_lint
 
       - name: Static code analysis
-        if: (matrix.magento != '2.4.0' && matrix.magento != '2.4.1')
         run: composer analyze
 
       - name: Unittests

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Magento: Magento 2.3.0 or higher
 PHPStan: PHPStan 2.0 or higher
 
 If you are using a Magento version that requires an older version of PHPStan (e.g. 0.12.77),  you need to manually upgrade it before 
-installing this extension. in your composer.json Change the PHPStan version to `~2.0` and run:
+installing this extension. In your composer.json Change the PHPStan version to `~2.0` and run:
 
 ```
 composer update phpstan/phpstan --with-all-dependencies

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -70,3 +70,18 @@ parameters:
         -
             message: '~PHPDoc tag @var assumes the expression with type~'
             path: tests/bitExpert/PHPStan/Magento/Type/TestFrameworkObjectManagerDynamicReturnTypeExtensionUnitTest.php
+        -
+            message: '~Parameter #2 \$scope of method~'
+            path: tests/bitExpert/PHPStan/Magento/Rules/AbstractModelRetrieveCollectionViaFactoryRuleUnitTest.php
+        -
+            message: '~Parameter #2 \$scope of method~'
+            path: tests/bitExpert/PHPStan/Magento/Rules/AbstractModelUseServiceContractRuleUnitTest.php
+        -
+            message: '~Parameter #2 \$scope of method~'
+            path: tests/bitExpert/PHPStan/Magento/Rules/GetCollectionMockMethodNeedsCollectionSubclassRuleUnitTest.php
+        -
+            message: '~Parameter #2 \$scope of method~'
+            path: tests/bitExpert/PHPStan/Magento/Rules/ResourceModelsShouldBeUsedDirectlyRuleUnitTest.php
+        -
+            message: '~Parameter #2 \$scope of method~'
+            path: tests/bitExpert/PHPStan/Magento/Rules/SetTemplateDisallowedForBlockRuleUnitTest.php


### PR DESCRIPTION
Replacing Magento 2.4.4, 2.4.5, 2.4.6 in the CI Pipeline with more recent 2.4.8 and 2.4.9 versions. All versions running on PHP 8.4 to make the whole enviroment more consistent.